### PR TITLE
add module colors to tailwind-config

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,7 +1,23 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  purge: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
+  darkMode: false, // or 'media' or 'class'
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
+    extend: {
+      colors: {
+        primary: '#1A202C', // text-gray-900
+        secondary: '#718096', // text-gray-600
+        subtitle: '#A0AEC0', // text-gray-500
+        'primary-green': '#2F855A', // text-green-800
+        'primary-darkgreen': '#22543D', // text-green-900
+        alert: '#E53E3E', // text-red-600
+        confirm: '#3182CE', // text-blue-600
+        light: '#F0FFF4', // bg-green-50
+      },
+    },
+  },
+  variants: {
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
the tailwind.config.js file now supports some basic primary,secondary,alert,confirm, title ,subtitle etc. colors to use abstractly throughout the app to ensure design consistency. To add more colors, take a look at ```tailwind.config.js``` and add more.

Usage : 
alert: '#E53E3E' is defined in tailwind.config.js

` <div className="bg-alert">`
` <p className="text-alert">`
